### PR TITLE
Update summary.md

### DIFF
--- a/docs/summary.md
+++ b/docs/summary.md
@@ -52,7 +52,6 @@
     * [.well-known](well-known.md)
     * [Custom Handle Implementation Guide](modules/id-repository/custom-handle.md)
   * [Inji](https://docs.mosip.io/inji)
-  * [Inji User Guide](inji-user-guide.md)
   * [Keycloak](keycloak.md)
   * [Key Manager](keymanager.md)
     * [Keys](keys.md)


### PR DESCRIPTION
Why are we still displaying a year-old version of Inji User Guide on the docs portal which seems to be outdated now? The end user guide for Inji should be a part of Inji documentation.