### PR TITLE
[INJIMOB-2367] add VCI-Client ios repo link and rm npm module

### DIFF
--- a/docs/inji-wallet/inji-mobile/technical-overview/components.md
+++ b/docs/inji-wallet/inji-mobile/technical-overview/components.md
@@ -108,16 +108,18 @@ Note:
 
 ### **6. VCI-client**
 
-VCI-Client library carries out the credential request from the consumer application (mobile wallet or web) and redirects the issuance/issuer. The library creates a request with the credential format, jwtproof of the wallet, issuer meta data and the access token received for authorization and provides VC as the response back to the consumer application for storage.
+VCI-Client library carries out the credential request from the consumer application (mobile wallet or web) and redirects the issuance/issuer. The library creates a request with the credential format, jwtproof of the wallet, issuer metadata and the access token received for authorization and provides VC as the response back to the consumer application for storage.
 
 {% hint style="info" %}
 Note:
 
-* Refer to the VCI-Client repository [here](https://github.com/mosip/inji-vci-client/blob/develop/README.md).
+* Refer to the VCI-Client repository 
+  * [kotlin](https://github.com/mosip/inji-vci-client/blob/master/kotlin/README.md)
+  * [swift](https://github.com/mosip/inji-vci-client-ios-swift)
 * To understand about the installation and the API documentation, refer [here](https://docs.mosip.io/inji/inji-mobile-wallet/integration-guide/vci-client).
-* To check the NPM module, click [here](https://www.npmjs.com/package/@mosip/inji-vci-client).
-* Maven snapshots are available [here](https://oss.sonatype.org/content/repositories/snapshots/io/mosip/inji-vci-client/)
+* Android artifacts are available [here](https://repo1.maven.org/maven2/io/mosip/inji-vci-client/)
 {% endhint %}
+
 
 ### **7. Telemetry**
 

--- a/docs/inji-wallet/inji-mobile/technical-overview/integration-guide/vci-client.md
+++ b/docs/inji-wallet/inji-mobile/technical-overview/integration-guide/vci-client.md
@@ -16,13 +16,12 @@ Below sections details on the steps for integrating the Kotlin and Swift package
 
 ### Repository
 
-* inji-vc-client repo is [here](https://github.com/mosip/inji-vci-client)
-* inji-vc-client-ios-swift repo is [here](https://github.com/mosip/inji-vci-client-ios-swift)
-* Maven snapshots available [here](https://repo1.maven.org/maven2/io/mosip/inji-vci-client/)
+* inji-vci-client repo is [here](https://github.com/mosip/inji-vci-client)
 
 ### Installation
 
-Snapshot builds are available [here](https://oss.sonatype.org/content/repositories/snapshots/io/mosip/inji-vci-client/).
+Builds are available [here](https://repo1.maven.org/maven2/io/mosip/inji-vci-client/).
+
 
 {% hint style="info" %}
 Note: implementation "io.mosip:inji-vci-client:0.1.0-SNAPSHOT"


### PR DESCRIPTION
Major changes include
- Add repo link for swift inji-vci-client
- Remove link for npm module of inji-vci-client as its not actively maintained as of now
- Replace inji-vci-client snapshot android artifact links with maven central urls