### PR TITLE
[MOSIP-44061] Update JDK 21 requirement in developer guide

### DIFF
--- a/docs/id-lifecycle-management/identity-verification/id-authentication-services/id-authentication-internal-service-developer-guide.md
+++ b/docs/id-lifecycle-management/identity-verification/id-authentication-services/id-authentication-internal-service-developer-guide.md
@@ -12,7 +12,7 @@ The documentation here will guide you through the prerequisites required for the
 
 Below is a list of tools required in ID Repository Services:
 
-1. JDK 11
+1. JDK 11 OR JDK 21
 2. Any IDE (like Eclipse or IntelliJ IDEA)
 3. Apache Maven (zip folder)
 4. pgAdmin

--- a/docs/id-lifecycle-management/identity-verification/id-authentication-services/id-authentication-otp-service-developer-guide.md
+++ b/docs/id-lifecycle-management/identity-verification/id-authentication-services/id-authentication-otp-service-developer-guide.md
@@ -10,7 +10,7 @@ The documentation here will guide you through the prerequisites required for the
 
 Below are a list of tools required in ID Repository Services:
 
-1. JDK 11
+1. JDK 11 OR JDK 21
 2. Any IDE (like Eclipse, IntelliJ IDEA)
 3. Apache Maven (zip folder)
 4. pgAdmin

--- a/docs/id-lifecycle-management/identity-verification/id-authentication-services/id-authentication-service-developer-guide.md
+++ b/docs/id-lifecycle-management/identity-verification/id-authentication-services/id-authentication-service-developer-guide.md
@@ -13,7 +13,7 @@ The documentation here will guide you through the prerequisites required for the
 
 Below are a list of tools required in ID Repository Services:
 
-1. JDK 11
+1. JDK 11 or JDK 21
 2. Any IDE (like Eclipse, IntelliJ IDEA)
 3. Apache Maven (zip folder)
 4. pgAdmin


### PR DESCRIPTION
Updated the JDK requirement to include JDK 21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated JDK compatibility across identity verification developer guides to accept JDK 11 or JDK 21.
  * Clarified prerequisites in authentication, internal-service, and OTP developer guides.
  * No other procedural or functional changes were made.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->