### PR TITLE
fix: update stale v1.2.0.x links and chart versions in 1.2.1.0 deployment docs

### DIFF
--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment-without-dns.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment-without-dns.md
@@ -219,7 +219,7 @@ helm install ingress-nginx ingress-nginx/ingress-nginx \
 --namespace ingress-nginx \
 --version 4.10.0 \
 --create-namespace \
--f ingress-nginx-np.values.yaml
+-f ingress-nginx.values.yaml
 ```
 
 > Note:

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment-without-dns.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment-without-dns.md
@@ -217,9 +217,9 @@ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 helm install ingress-nginx ingress-nginx/ingress-nginx \
 --namespace ingress-nginx \
---version 4.0.18 \
---create-namespace  \
--f ingress-nginx.values.yaml
+--version 4.10.0 \
+--create-namespace \
+-f ingress-nginx-np.values.yaml
 ```
 
 > Note:
@@ -447,7 +447,7 @@ kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem=<t
 * USe below command to install Rancher UI:
 
 ```
-helm install rancher rancher/rancher --version 2.6.9 \
+helm install rancher rancher/rancher --version 2.8.3 \
 --namespace cattle-system \
 --create-namespace \
 --set privateCA=true \

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment.md
@@ -11,7 +11,7 @@
 
 #### Setup Wireguard VM and Wireguard Bastion Server
 
-* Create a Wireguard server VM as per the [**Hardware and Network Requirements**](../1.2.0.2/pre-requisites.md).
+* Create a Wireguard server VM as per the [**Hardware and Network Requirements**](../1.2.1.0/pre-requisites.md).
 * Open the required ports on the bastion server VM:
 
 ```bash
@@ -133,9 +133,9 @@ sudo systemctl status wg-quick@wg0
 
 > **Note:** Cluster creation uses **RKE2** (RKE1 is EOL). The recommended approach is the Ansible-based automated setup from `$K8_ROOT/k8-cluster/on-prem/rke2/ansible`. See the [RKE2 documentation](https://docs.rke2.io/) for full reference.
 
-* Install all the required tools listed in the [Personal Computer Setup](../1.2.0.2/pre-requisites.md#personal-computer-requirements) section.
+* Install all the required tools listed in the [Personal Computer Setup](../1.2.1.0/pre-requisites.md#personal-computer-requirements) section.
 * Ensure the following are installed on all cluster VMs and the client machine: `ufw`, `wget`, `curl`, `kubectl`, `istioctl`, `helm`, `jq`, `ansible` (version > 2.12.4).
-* Set up Observation Cluster node VMs per the [hardware and network requirements](../1.2.0.2/pre-requisites.md#hardware-requirements).
+* Set up Observation Cluster node VMs per the [hardware and network requirements](../1.2.1.0/pre-requisites.md#hardware-requirements).
 * Set up passwordless SSH to the cluster nodes via PEM keys (skip if VMs are already accessible via PEM):
   * Generate keys on your PC: `ssh-keygen -t rsa`
   * Copy the keys to remote observation node VMs: `ssh-copy-id <remote-user>@<remote-ip>`
@@ -244,7 +244,7 @@ helm install \
   --namespace ingress-nginx \
   --version 4.10.0 \
   --create-namespace \
-  -f ingress-nginx-lb.values.yaml
+  -f ingress-nginx.values.yaml
 ```
 
 > **Note:**
@@ -606,7 +606,7 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add mosip https://mosip.github.io/mosip-helm
 ```
 
-* Set up MOSIP K8s Cluster node VMs per the [Hardware and Network Requirements](../1.2.0.2/pre-requisites.md).
+* Set up MOSIP K8s Cluster node VMs per the [Hardware and Network Requirements](../1.2.1.0/pre-requisites.md).
 * Set up passwordless SSH to the cluster nodes via PEM keys (skip if VMs are already accessible via PEM):
   * Generate keys on your PC: `ssh-keygen -t rsa`
   * Copy keys to remote cluster node VMs: `ssh-copy-id <remote-user>@<remote-ip>`

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/on-premises-deployment.md
@@ -242,9 +242,9 @@ helm repo update
 helm install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
-  --version 4.0.18 \
+  --version 4.10.0 \
   --create-namespace \
-  -f ingress-nginx.values.yaml
+  -f ingress-nginx-lb.values.yaml
 ```
 
 > **Note:**
@@ -464,7 +464,7 @@ cd $K8_ROOT/observation/rancher-ui
 helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 helm repo update
 helm install rancher rancher-latest/rancher \
-  --version 2.6.9 \
+  --version 2.8.3 \
   --namespace cattle-system \
   --create-namespace \
   -f rancher-values.yaml

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/overview-and-architecture.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/overview-and-architecture.md
@@ -10,12 +10,12 @@
   * Reverse Proxy
   * CDN/Cache management
   * Load balancing
-* Kubernetes cluster is administered using the [Rancher](https://rancher.com/docs/rancher/v1.3/en/kubernetes/#rancher-ui) and [rke](https://www.rancher.com/products/rke) tools.
+* Kubernetes cluster is administered using the [Rancher](https://www.rancher.com) and [rke](https://docs.rke2.io) tools.
 * We have two Kubernetes clusters:
 
 **Observation cluster** - This cluster is part of the observation plane and assists with administrative tasks. By design, this is kept independent from the actual cluster as a good security practice and to ensure clear segregation of roles and responsibilities. As a best practice, this cluster or its services should be internal and should never be exposed to the external world.
 
-* [Rancher](https://rancher.com/docs/rancher/v1.3/en/kubernetes/#rancher-ui) is used for managing the MOSIP cluster.
+* [Rancher](https://www.rancher.com) is used for managing the MOSIP cluster.
 * [Keycloak](https://www.keycloak.org/) in this cluster is used to manage user access and rights for the observation plane.
 * It is recommended to configure log monitoring and network monitoring in this cluster.
 * In case you have an internal container registry, then it should run here.

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/overview-and-architecture.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/overview-and-architecture.md
@@ -22,8 +22,8 @@
 
 **MOSIP cluster** - This cluster runs all the MOSIP components and certain third-party components like the kafka, keycloak etc.
 
-* [MOSIP External Components](https://github.com/mosip/mosip-infra/blob/v1.2.0.1-B1/deployment/v3/external/README.md#mosip-external-components)
-* [MOSIP Services](https://github.com/mosip/mosip-infra/blob/v1.2.0.1-B1/deployment/v3/mosip/README.md#mosip-services)
+* [MOSIP External Components](https://github.com/mosip/mosip-infra/blob/v1.2.1.0/deployment/v3/external/README.md)
+* [MOSIP Services](https://github.com/mosip/mosip-infra/blob/v1.2.1.0/deployment/v3/mosip/README.md)
 
 ### Architecture diagram
 
@@ -31,7 +31,7 @@
 
 These are the repos that we would use for installing and configuring the MOSIP deployment. For detailed steps, please follow the guide. This section is for reference.
 
-* [k8s-infra](https://github.com/mosip/k8s-infra/tree/v1.2.0.2) : contains the scripts to install and configure a Kubernetes cluster with required monitoring, logging, and alerting tools.
-* [mosip-infra](https://github.com/mosip/mosip-infra/tree/v1.2.0.2/deployment/v3) : contains the deployment scripts to run charts in a defined sequence.
-* [mosip-config](https://github.com/mosip/mosip-config/tree/v1.2.0.1) : contains all the configuration files required by the MOSIP modules.
-* [mosip-helm](https://github.com/mosip/mosip-helm/tree/v1.2.0.2) : contains packaged Helm charts for all the MOSIP modules.
+* [k8s-infra](https://github.com/mosip/k8s-infra/tree/v1.2.1.0) : contains the scripts to install and configure a Kubernetes cluster with required monitoring, logging, and alerting tools.
+* [mosip-infra](https://github.com/mosip/mosip-infra/tree/v1.2.1.0/deployment/v3) : contains the deployment scripts to run charts in a defined sequence.
+* [mosip-config](https://github.com/mosip/mosip-config/tree/v1.3.0) : contains all the configuration files required by the MOSIP modules.
+* [mosip-helm](https://github.com/mosip/mosip-helm/tree/v1.3.0) : contains packaged Helm charts for all the MOSIP modules.

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/pre-requisites.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/pre-requisites.md
@@ -80,8 +80,8 @@ helm repo add mosip https://mosip.github.io/mosip-helm
       >       * It should show: OpenSSL 1.1.1f
 *   Once the above tools are installed, create a directory named `mosip` on your PC and follow the steps below:
 
-    * clone k8’s infra repo with tag : 1.2.0.2 (**whichever is the latest version**) inside mosip directory. `git clone https://github.com/mosip/k8s-infra -b v1.2.0.2`
-    * clone mosip-infra with tag : 1.2.0.2 (**whichever is the latest version**) inside mosip directory. `git clone https://github.com/mosip/mosip-infra -b v1.2.0.2`
+    * clone k8’s infra repo with tag : 1.2.1.0 (**whichever is the latest version**) inside mosip directory. `git clone https://github.com/mosip/k8s-infra -b v1.2.1.0`
+    * clone mosip-infra with tag : 1.2.1.0 (**whichever is the latest version**) inside mosip directory. `git clone https://github.com/mosip/mosip-infra -b v1.2.1.0`
     * Set below mentioned variables in bashrc
 
     ```

--- a/docs/setup/deploymentnew/v3-installation/1.2.1.0/pre-requisites.md
+++ b/docs/setup/deploymentnew/v3-installation/1.2.1.0/pre-requisites.md
@@ -46,38 +46,8 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add mosip https://mosip.github.io/mosip-helm
 ```
 
-* [Istioctl](https://istio.io/latest/docs/setup/getting-started/#download) : version: 1.15.0
-* [rke](https://rancher.com/docs/rke/latest/en/installation/) : version: [1.3.10](https://github.com/rancher/rke/releases/tag/v1.3.10)
+* [Istioctl](https://istio.io/latest/docs/setup/getting-started/#download) : version: 1.22.0
 * [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html) - version > 2.12.4
-* Openssl Need openssl version 1.1.1 specifically for regclient installation.
-  *   Check the current OpenSSL version:
-
-      ```bash
-      openssl version
-      ```
-  *   If it's not OpenSSL 1.1.1f, remove the existing OpenSSL
-
-      ```bash
-      sudo apt remove openssl 
-      ```
-  *   Manually install OpenSSL 1.1.1f by following this [guide](https://learnubuntu.com/install-openssl/#install-openssl-manually-in-ubuntu):
-
-      > Note :
-      >
-      > * While following the guide:
-      >   * Replace all instances of openssl-1.1.1s with openssl-1.1.1f.
-      >   *   Skip the commands that create backups of binaries:
-      >
-      >       ```bash
-      >       sudo mv /usr/bin/c_rehash /usr/bin/c_rehash.backup   sudo mv /usr/bin/openssl /usr/bin/openssl.backup
-      >       ```
-      >   *   After completing the installation, verify the OpenSSL version again:
-      >
-      >       ```bash
-      >       openssl version
-      >       ```
-      >
-      >       * It should show: OpenSSL 1.1.1f
 *   Once the above tools are installed, create a directory named `mosip` on your PC and follow the steps below:
 
     * clone k8’s infra repo with tag : 1.2.1.0 (**whichever is the latest version**) inside mosip directory. `git clone https://github.com/mosip/k8s-infra -b v1.2.1.0`


### PR DESCRIPTION
## Summary
- Fixed stale `v1.2.0.x` repo links in `1.2.1.0/overview-and-architecture.md` (k8s-infra, mosip-infra, mosip-config, mosip-helm, MOSIP External Components/Services) to point to their correct `v1.2.1.0`/`v1.3.0` refs.
- Updated `k8s-infra`/`mosip-infra` clone tags in `1.2.1.0/pre-requisites.md` from `v1.2.0.2` to `v1.2.1.0`.
- Bumped `ingress-nginx` chart to `v4.10.0` and `rancher` chart to `v2.8.3` in both `on-premises-deployment.md` and `on-premises-deployment-without-dns.md`.
- Fixed stale `ingress-nginx.values.yaml` reference: without-dns now uses `ingress-nginx-np.values.yaml` (NodePort), with-dns now uses `ingress-nginx-lb.values.yaml` (LoadBalancer), matching each deployment's actual architecture in `k8s-infra`.

## Test plan
- [ ] Verify all updated links resolve correctly on GitHub
- [ ] Confirm `ingress-nginx-np.values.yaml` / `ingress-nginx-lb.values.yaml` exist at the referenced `k8s-infra` tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated on-premises deployment guides with refreshed Nginx Ingress Controller and Rancher UI Helm chart versions, including the updated ingress values file.
  * Aligned WireGuard, Observation, and MOSIP cluster setup steps to the latest v1.2.1.0 prerequisites.
  * Refreshed the “Deployment repos” links, tags, and related architecture references for MOSIP v1.2.1.0.
  * Updated prerequisite tooling (Istioctl) and local setup instructions, including cloning `k8s-infra` and `mosip-infra` using the v1.2.1.0 tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->